### PR TITLE
Feat: no verifying contract

### DIFF
--- a/pkg/eip712/constants.go
+++ b/pkg/eip712/constants.go
@@ -13,10 +13,19 @@ var (
 		Uint256, // chainId
 		Address, // verifyingContract
 	}
-)
 
-var (
 	_EIP712_DOMAIN_HASH = crypto.Keccak256Hash(
 		[]byte("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+	)
+
+	_EIP712_DOMAIN_NO_VERIFYING_CONTRACT = []abi.Type{
+		Bytes32, // typehash
+		Bytes32, // name
+		Bytes32, // version
+		Uint256, // chainId
+	}
+
+	_EIP712_DOMAIN_HASH_NO_VERIFYING_CONTRACT = crypto.Keccak256Hash(
+		[]byte("EIP712Domain(string name,string version,uint256 chainId)"),
 	)
 )

--- a/pkg/eip712/eip712.go
+++ b/pkg/eip712/eip712.go
@@ -26,6 +26,22 @@ func BuildEIP712DomainSeparator(name, version common.Hash, chainId *big.Int, add
 	return crypto.Keccak256Hash(encodedDomainSeparator), nil
 }
 
+func BuildEIP712DomainSeparatorNoContract(name, version common.Hash, chainId *big.Int) (common.Hash, error) {
+	values := []interface{}{
+		_EIP712_DOMAIN_HASH_NO_VERIFYING_CONTRACT,
+		name,
+		version,
+		chainId,
+	}
+
+	encodedDomainSeparator, err := Encode(_EIP712_DOMAIN_NO_VERIFYING_CONTRACT, values)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	return crypto.Keccak256Hash(encodedDomainSeparator), nil
+}
+
 func HashTypedDataV4(domainSeparator common.Hash, args []abi.Type, values []interface{}) (common.Hash, error) {
 	encoded, err := Encode(args, values)
 	if err != nil {

--- a/pkg/eip712/eip712_test.go
+++ b/pkg/eip712/eip712_test.go
@@ -33,6 +33,30 @@ func TestBuildEIP712DomainSeparator(t *testing.T) {
 	assert.Equal(t, expectedPolygon, actual[:])
 }
 
+func TestBuildEIP712DomainSeparatorNoContract(t *testing.T) {
+	// Calculated in foundry
+	expectedMumbai := common.Hex2Bytes("4a3577f6d2decf700867987650d4fe51bd2b991c2e7603094244852187451f06")
+	chainId := big.NewInt(80001)
+
+	name := crypto.Keccak256Hash([]byte("Polymarket CTF Exchange"))
+	version := crypto.Keccak256Hash([]byte("1"))
+
+	actual, err := BuildEIP712DomainSeparatorNoContract(name, version, chainId)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, actual)
+	assert.Equal(t, expectedMumbai, actual[:])
+
+	// Calculated in foundry
+	expectedPolygon := common.Hex2Bytes("aee1d7dd93bb10f6c6a59417017905bc5dbec7ddbd71475cd19d8a95845e632d")
+	chainId = big.NewInt(137)
+
+	actual, err = BuildEIP712DomainSeparatorNoContract(name, version, chainId)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, actual)
+	assert.NotEqual(t, expectedMumbai, actual[:])
+	assert.Equal(t, expectedPolygon, actual[:])
+}
+
 func TestHashTypedDataV4(t *testing.T) {
 	name := crypto.Keccak256Hash([]byte("Polymarket CTF Exchange"))
 	version := crypto.Keccak256Hash([]byte("1"))


### PR DESCRIPTION
- Build the EIP712 domain separator without the verifying contract for lower security scenarios