### PR TITLE
fix: Adjust error handling for invalid sig length

### DIFF
--- a/pkg/signer/signer.go
+++ b/pkg/signer/signer.go
@@ -3,10 +3,10 @@ package signer
 import (
 	"bytes"
 	"crypto/ecdsa"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 )
 
 func Sign(privateKey *ecdsa.PrivateKey, hashedData common.Hash) ([]byte, error) {
@@ -23,7 +23,7 @@ func ValidateSignature(signer common.Address, hashedData common.Hash, signature 
 	copy(sigCopy, signature)
 
 	if len(sigCopy) != 65 {
-		return false, secp256k1.ErrInvalidSignatureLen
+		return false, fmt.Errorf("invalid signature length")
 	}
 
 	if sigCopy[64] != 0 && sigCopy[64] != 1 { // in case of ledger signing v might already be 0 or 1


### PR DESCRIPTION
- Use an fmt error instead of importing the sig length error
- This resolves the build with CGO_ENABLED=0 when using this library.

This resolves the following error when using this in a static lib compilation:
```
github.com/polymarket/go-order-utils/pkg/signer
# github.com/polymarket/go-order-utils/pkg/signer
../../../go/pkg/mod/github.com/polymarket/go-order-utils@v1.22.3/pkg/signer/signer.go:26:27: undefined: secp256k1.ErrInvalidSignatureLen
```