### PR TITLE
[chore] Fix conflicting secp256k1 in dependency graph

### DIFF
--- a/pkg/signer/signer.go
+++ b/pkg/signer/signer.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/crypto/secp256k1"
+	ethsecp256k1 "github.com/ethereum/go-ethereum/crypto/secp256k1"
 )
 
 func Sign(privateKey *ecdsa.PrivateKey, hashedData common.Hash) ([]byte, error) {
@@ -23,7 +23,7 @@ func ValidateSignature(signer common.Address, hashedData common.Hash, signature 
 	copy(sigCopy, signature)
 
 	if len(sigCopy) != 65 {
-		return false, secp256k1.ErrInvalidSignatureLen
+		return false, ethsecp256k1.ErrInvalidSignatureLen
 	}
 
 	if sigCopy[64] != 0 && sigCopy[64] != 1 { // in case of ledger signing v might already be 0 or 1


### PR DESCRIPTION
importing `go-ethereum`'s `secp256k1` package without an alias causes issues in downstream projects who also depend on `btcd/btcec/v2/ecdsa` which has a hard dependency on `decred/secp256k1/v4/ecdsa`