### PR TITLE
Add Makefile command to generate test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ test:
 	@echo "----------------------------------------------------------------"
 	@echo " ⚙️  Testign the code..."
 	@echo "----------------------------------------------------------------"
-	GOPRIVATE=${PRIVATE_REPOS} go test ./... -v
+	GOPRIVATE=${PRIVATE_REPOS} go test -coverprofile cover.out ./... -v
 	@echo "Tests complete!"
 
-.PHONE: build
-build:
-	@echo
+.PHONY: test.coverage
+test.coverage: test
+	go tool cover -html=cover.out


### PR DESCRIPTION
Add Makefile command to generate test coverage. Running the following command will generate a coverage report that can be viewed inside of a brower.

```sh
make test.coverage
```

<img width="1025" height="685" alt="Screenshot 2025-08-31 at 12 44 08 AM" src="https://github.com/user-attachments/assets/8ed07690-3cc4-4650-bf17-d5a25f40527c" />